### PR TITLE
Due to circular dependencies, for now, PBS adn Slurm exec must be cal…

### DIFF
--- a/jarvis_util/shell/exec.py
+++ b/jarvis_util/shell/exec.py
@@ -2,8 +2,6 @@
 This module provides mechanisms to execute binaries either locally or
 remotely.
 """
-from jarvis_util.shell.pbs_exec import PbsExec
-from jarvis_util.shell.slurm_exec import SlurmExec
 from .local_exec import LocalExec
 from .pssh_exec import PsshExec
 from .pssh_exec import SshExec
@@ -36,10 +34,6 @@ class Exec(Executable):
             self.exec_ = PsshExec(cmd, exec_info)
         elif exec_type == ExecType.MPI:
             exec_type = MpiVersion(exec_info).version
-        elif exec_type == ExecType.SLURM:
-            exec_type = SlurmExec(cmd, exec_info)
-        elif exec_type == ExecType.PBS:
-            exec_type = PbsExec(cmd, exec_info)
 
         if exec_type == ExecType.MPICH:
             self.exec_ = MpichExec(cmd, exec_info)


### PR DESCRIPTION
…led diorectly instead of using the exec factory thingy